### PR TITLE
Add path for folders results when searching

### DIFF
--- a/sidebar/panel.css
+++ b/sidebar/panel.css
@@ -437,7 +437,7 @@ tbody {
   text-align: end;
   font-style: italic;
   font-size: 90%;
-  padding-left: 10%;
+  padding-left: 10px;
   opacity: 0.6;
   overflow-x: hidden;
   text-overflow: ellipsis;

--- a/sidebar/panel.css
+++ b/sidebar/panel.css
@@ -226,6 +226,8 @@ p {
 table {
   min-width: 100%;
   border-spacing: 0;
+  width: 100%;
+  table-layout: fixed;
 }
 
 tbody {
@@ -323,6 +325,10 @@ tbody {
   border-bottom: solid 2px transparent;
   margin-top: -2px;
   margin-bottom: -2px;
+  width: 100%;
+  padding-right: 4px;
+  display: flex;
+  flex-direction: row;
 }
 
 .bkmkitem_s {
@@ -375,6 +381,7 @@ tbody {
   vertical-align: text-bottom;
   background-image: url("/icons/rtwistieac.png");
   cursor: default;
+  flex: inherit;
 }
 
 .brow:hover .twistieac, .selbrow:hover .twistieac {
@@ -400,6 +407,7 @@ tbody {
   width: 16px;
   vertical-align: text-bottom;
   background-image: url("/icons/folder.png");
+  flex: inherit;
 }
 
 .nofavicon {
@@ -420,6 +428,17 @@ tbody {
 .favtext {
   margin-left: 3px;
   white-space: pre;
+  flex: inherit;
+}
+
+.favpath {
+  font-style: italic;
+  font-size: 90%;
+  color: grey;
+  margin-left: auto;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  padding-left: 10%;
 }
 
 .mymenu {

--- a/sidebar/panel.css
+++ b/sidebar/panel.css
@@ -1,4 +1,4 @@
-:root{
+:root {
   --bg-color: white; 
   --txt-color: #222426;
 }
@@ -200,11 +200,10 @@ p {
 }
 
 #trace {
-  width: 200px;
+  width: calc(100% - 9px);
   resize: none;
   font-size: x-small;
   white-space: pre;
-  overflow: visible;
   flex: none;
   margin-left: 4px;
 }
@@ -226,8 +225,11 @@ p {
 table {
   min-width: 100%;
   border-spacing: 0;
+}
+
+#resultstable {
   width: 100%;
-  table-layout: fixed;
+  table-layout: fixed;	
 }
 
 tbody {
@@ -375,13 +377,13 @@ tbody {
 }
 
 .rtwistieac {
+  flex: none;
   display: inline-block;
   height: 16px;
   width: 16px;
   vertical-align: text-bottom;
   background-image: url("/icons/rtwistieac.png");
   cursor: default;
-  flex: inherit;
 }
 
 .brow:hover .twistieac, .selbrow:hover .twistieac {
@@ -402,12 +404,12 @@ tbody {
 }
 
 .ffavicon {
+  flex: none;
   display: inline-block;
   height: 16px;
   width: 16px;
   vertical-align: text-bottom;
   background-image: url("/icons/folder.png");
-  flex: inherit;
 }
 
 .nofavicon {
@@ -428,17 +430,17 @@ tbody {
 .favtext {
   margin-left: 3px;
   white-space: pre;
-  flex: inherit;
 }
 
-.favpath {
+.rfavpath {
+  flex-grow: 1;
+  text-align: end;
   font-style: italic;
   font-size: 90%;
-  color: grey;
-  margin-left: auto;
+  padding-left: 10%;
+  opacity: 0.6;
   overflow-x: hidden;
   text-overflow: ellipsis;
-  padding-left: 10%;
 }
 
 .mymenu {

--- a/sidebar/panel.html
+++ b/sidebar/panel.html
@@ -18,7 +18,7 @@
   <div id="searchresult" class="rscrollok" hidden=true>
     <img src="/icons/waiting.gif" height="20px" id="waitingsearch">
 <!--
-    <table><tbody>
+    <table id="resultstable"><tbody>
       <tr data-id=".." data-type="bookmark" data-rslt="true"><td class="brow" tabindex="0" draggable="false">
         <div class="rbkmkitem_b" href=".." draggable="false">
           <img src="/icons/nofavicon.png" class="favicon" draggable="false">

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -5137,7 +5137,7 @@ console.log("dt.types        : "+dt.types);
 	// Note: when the mouse is over the lifts, an HTMLDivElement is returned
 	let row = getDragToRow(target);
 //console.log("Drop on row: "+row+" class: "+row.classList+" BN_id: "+row.dataset.id);
-traceDt(dt);
+//traceDt(dt);
 
 	// Can't happen when in a dropEffect=none zone .. but in case, let's protect against it
 	let is_ctrlKey = (isMacOS ? e.metaKey : e.ctrlKey); // When Ctrl is pressed, this is a copy, no protection
@@ -5381,19 +5381,39 @@ console.log("tabs length: "+len);
 			   || types.includes(type = "text/x-moz-url")	// Dragging the location bar URL address
 			  ) {
 		let url = dt.getData(type);
-		let title = dt.getData("text/x-moz-url-desc");
-		if (title.length == 0) {
-		  title = dt.getData("text/x-moz-url");
+		// Try the URL description type
+		let title = dt.getData("text/x-moz-url-desc").trim();
+		let splitIndex = title.indexOf("\n"); // Remove any "\n" and following part if there is in title 
+		if (splitIndex > 0) {
+		  title = title.slice(0, splitIndex);
 		}
 
-		let splitIndex = url.indexOf("\n"); // Remove any "\n" and following part if there is in URL 
+		// Get URL
+		splitIndex = url.indexOf("\n"); // Remove any "\n" and following part if there is in URL
 		if (splitIndex > 0) {
 		  url = url.slice(0, splitIndex);
 		}
-		if (title.length == 0) { // If title is empty, use the URL as title
+		if (url.startsWith("https://www.google.com/url?")) { // Handle Google search result drag = simplify it
+		  splitIndex = url.indexOf("&url="); // Remove any "&url=" and parts before
+		  if (splitIndex > 0) {
+			url = url.slice(splitIndex+5);
+			splitIndex = url.indexOf("&"); // Remove any following "&" and parts after, to keep only the real URL
+			if (splitIndex > 0) {
+			  url = url.slice(0, splitIndex);
+			}
+			// Decode the URL
+			url = decodeURIComponent(url);
+		  }
+		}
+
+		// Adjust title if empty
+		if (title.length == 0) { // If title is empty, try the URL content (e.g. location bar drag & drop)
+		  title = dt.getData("text/x-moz-url");
+		}
+		if (title.length == 0) { // If title is still empty, use the URL as title
 		  title = url;
 		}
-		else { // If there is an "\n", keep the part after
+		else { // If there is an "\n", keep the part after (can only be for "text/x-moz-url", e.g. location bar drag & drop)
 		  splitIndex = title.indexOf("\n");
 		  title = title.slice(splitIndex+1);
 		}

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -252,6 +252,10 @@ tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
 tmpElem1.classList.add("favtext");
 tmpElem1.draggable = false; // False by default for <span>
 RFolderTempl.appendChild(tmpElem1);
+tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
+tmpElem1.classList.add("favpath");
+tmpElem1.draggable = false; // False by default for <span>
+RFolderTempl.appendChild(tmpElem1);
 /*
  *******  Prepare special Folder structure for node cloning
  */
@@ -286,6 +290,10 @@ tmpElem1.draggable = false; // True by default for <img>
 RSFolderTempl.appendChild(tmpElem1);
 tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
 tmpElem1.classList.add("favtext");
+tmpElem1.draggable = false; // False by default for <span>
+RSFolderTempl.appendChild(tmpElem1);
+tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
+tmpElem1.classList.add("favpath");
 tmpElem1.draggable = false; // False by default for <span>
 RSFolderTempl.appendChild(tmpElem1);
 /*
@@ -560,6 +568,7 @@ function appendResult (BN) {
 	// Create elements
 	let div2;
 	let span;
+	let path_span;
 	if (BN.fetchedUri) { // Special bookmark folder with special favicon
 	  div2 = RSFolderTempl.cloneNode(true);
 	  let img = div2.firstElementChild.nextElementSibling;
@@ -573,6 +582,9 @@ function appendResult (BN) {
 	if (BN.inBSP2Trash) { // Set to italics
 	  span.style.fontStyle = "italic";
 	}
+
+	path_span = div2.firstElementChild.nextElementSibling.nextElementSibling.nextElementSibling;
+	path_span.textContent = BN_path(BN.parentId);
 
 	let title = BN.title;
 	if (showPath_option) {

--- a/sidebar/panel.js
+++ b/sidebar/panel.js
@@ -253,7 +253,7 @@ tmpElem1.classList.add("favtext");
 tmpElem1.draggable = false; // False by default for <span>
 RFolderTempl.appendChild(tmpElem1);
 tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
-tmpElem1.classList.add("favpath");
+tmpElem1.classList.add("rfavpath");
 tmpElem1.draggable = false; // False by default for <span>
 RFolderTempl.appendChild(tmpElem1);
 /*
@@ -293,7 +293,7 @@ tmpElem1.classList.add("favtext");
 tmpElem1.draggable = false; // False by default for <span>
 RSFolderTempl.appendChild(tmpElem1);
 tmpElem1 = document.createElement("span"); // Assuming it is an HTMLSpanElement
-tmpElem1.classList.add("favpath");
+tmpElem1.classList.add("rfavpath");
 tmpElem1.draggable = false; // False by default for <span>
 RSFolderTempl.appendChild(tmpElem1);
 /*
@@ -561,6 +561,7 @@ function appendResult (BN) {
   //   - a <div> (class "rtwistiexx") if a folder
   //   - an <div>, or <img> if special folder, (class "favicon")
   //   - and a <span> with text (class "favtext")
+  //   - for folder results, additionally, a <span> with path to the folder (class "rfavpath") 
   if (type == "folder") {				// Folder
 	// Mark that row as folder
 	row.dataset.type = "folder";
@@ -568,7 +569,7 @@ function appendResult (BN) {
 	// Create elements
 	let div2;
 	let span;
-	let path_span;
+	let pathspan;
 	if (BN.fetchedUri) { // Special bookmark folder with special favicon
 	  div2 = RSFolderTempl.cloneNode(true);
 	  let img = div2.firstElementChild.nextElementSibling;
@@ -582,19 +583,20 @@ function appendResult (BN) {
 	if (BN.inBSP2Trash) { // Set to italics
 	  span.style.fontStyle = "italic";
 	}
-
-	path_span = div2.firstElementChild.nextElementSibling.nextElementSibling.nextElementSibling;
-	path_span.textContent = BN_path(BN.parentId);
-
 	let title = BN.title;
+	span.textContent = title;
+//	span.draggable = false;
+
+	pathspan = span.nextElementSibling;
+	let p = pathspan.textContent = BN_path(BN.parentId);
+//	pathspan.draggable = false;
+
 	if (showPath_option) {
-	  div2.title = BN_path(BN.parentId);
+	  div2.title = p;
 	}
 	else {
 	  div2.title = title;
 	}
-	span.textContent = title;
-//	span.draggable = false;
 	cell.appendChild(div2);
   }
   else {								// "bookmark"
@@ -615,7 +617,7 @@ function appendResult (BN) {
 	  anchor = RNFBookmarkTempl.cloneNode(true);
 	  span = anchor.firstElementChild.nextElementSibling;
 	}
-	else { // clone normal one, and fill image
+	else { // Clone normal one, and fill image
 	  anchor = RBookmarkTempl.cloneNode(true);
 	  let img = anchor.firstElementChild;
 	  img.src = uri;
@@ -933,6 +935,7 @@ function displayResults (a_BTN) {
   // Create search results table
 //  resultsFragment = document.createDocumentFragment();
   resultsTable = document.createElement("table");
+  resultsTable.id = "resultstable";
   SearchResult.appendChild(resultsTable); // Display the search results table + reflow
 //  resultsFragment.appendChild(resultsTable);
 
@@ -979,7 +982,7 @@ let searchlistTimeoutId;
 function closeSearchList () {
   searchlistTimeoutId == undefined;
   SearchTextInput.blur(); // This closes the search list
-  SearchTextInput.focus(); // Givz back focus to be able to type again
+  SearchTextInput.focus(); // Give back focus to be able to type again
   let l = SearchTextInput.value.length; // Focus is selecting all text in the input => de-select to type at end ...
   SearchTextInput.setSelectionRange(l, l);
 }
@@ -5134,7 +5137,7 @@ console.log("dt.types        : "+dt.types);
 	// Note: when the mouse is over the lifts, an HTMLDivElement is returned
 	let row = getDragToRow(target);
 //console.log("Drop on row: "+row+" class: "+row.classList+" BN_id: "+row.dataset.id);
-//traceDt(dt);
+traceDt(dt);
 
 	// Can't happen when in a dropEffect=none zone .. but in case, let's protect against it
 	let is_ctrlKey = (isMacOS ? e.metaKey : e.ctrlKey); // When Ctrl is pressed, this is a copy, no protection
@@ -7142,7 +7145,7 @@ if (traceEnabled_option) {
 		  }
 		  // If a show path option changed, update any open search result 
 		  if ((showPath_option_old != showPath_option)
-			  || (showPath_option && (reversePath_option_old != reversePath_option))
+			  || (reversePath_option_old != reversePath_option)
 			 ) {
 			// Trigger an update as results can change, if there is a search active
 			triggerUpdate();


### PR DESCRIPTION
Related to #207 

# Context

For some "generic words", the search results are not very explicit whereas it would be if the parent folder or the full path could be visible.

Even with the option which makes the path visible when you hover the mouse on the result, I ended spending too much times waiting the hover section to appear.

As I mostly do folder searches, I would prefer a faster solution. 

# Feature

- Add the folder path on the right of the folder search results with a lighter police
- Change the style to restrict to fit the 100% width body and allow to ellipsis when too long
- The path is always visible for now. But I can add an option in the search menu or in the extension preferences if necessary.

# Examples

![2022-09-18_15-44 search folder path ex1](https://user-images.githubusercontent.com/7831572/190909211-f857155a-8891-48c7-9198-ba6f98b9f696.png)

![2022-09-18_15-44 search folder path ex1 shrink mode](https://user-images.githubusercontent.com/7831572/190909409-4657de44-61f2-4f8b-9d5a-5e994c21c1c9.png)

![2022-09-18_15-44 search folder path ex3](https://user-images.githubusercontent.com/7831572/190909607-2914e412-2027-4b2d-95b9-62dd5381a924.png)